### PR TITLE
Hide notification bell on faculty dashboard

### DIFF
--- a/apps/web/app/(dashboards)/layout.tsx
+++ b/apps/web/app/(dashboards)/layout.tsx
@@ -2,6 +2,7 @@
 import { SidebarProvider } from '@workspace/ui/components/sidebar'
 import { MainAppSidebar } from './sidebar'
 import { useState } from 'react'
+import { usePathname } from 'next/navigation'
 import { Navbar } from '@/components/layout/navbar'
 
 type Props = {
@@ -10,13 +11,15 @@ type Props = {
 
 const SidebarLayout = ({children}: Props) => {
   const [activeSection, setActiveSection] = useState<string | null>(null)
+  const pathname = usePathname()
+  const showNotifications = !pathname.startsWith('/faculty')
 
   return (
     <SidebarProvider>
     <div className="flex h-screen w-full overflow-hidden bg-background">
        <MainAppSidebar activeSection={activeSection} setActiveSection={setActiveSection} />
       <div className="flex flex-1 flex-col overflow-hidden">
-      <Navbar />
+      <Navbar showNotifications={showNotifications} />
         <main className="flex-1 overflow-y-auto p-4 md:p-6">
           {children}
         </main>

--- a/apps/web/app/(dashboards)/layout.tsx
+++ b/apps/web/app/(dashboards)/layout.tsx
@@ -12,7 +12,9 @@ type Props = {
 const SidebarLayout = ({children}: Props) => {
   const [activeSection, setActiveSection] = useState<string | null>(null)
   const pathname = usePathname()
-  const showNotifications = !pathname.startsWith('/faculty')
+  const hideNotificationRoutes = ['/faculty']
+const showNotifications = !hideNotificationRoutes.some(route => pathname.startsWith(route))
+
 
   return (
     <SidebarProvider>


### PR DESCRIPTION
used usePathname() to get the current route
added showNotifications prop in Navbar
hid the notification bell on /dashboard/faculty

## Summary by Sourcery

Hide the notification bell on the faculty dashboard by conditionally rendering notifications based on the current route

New Features:
- Add route-based conditional rendering of notification bell

Enhancements:
- Modify Navbar component to accept a showNotifications prop to control notification bell visibility