### PR TITLE
Removed bell and help icons from QOC dashboard

### DIFF
--- a/apps/web/components/layout/navbar.tsx
+++ b/apps/web/components/layout/navbar.tsx
@@ -8,6 +8,8 @@ import { Button } from "@workspace/ui/components/button"
 import { Input } from "@workspace/ui/components/input"
 import { SidebarTrigger } from "@workspace/ui/components/sidebar"
 import { ThemeToggle } from "@workspace/ui/components/theme-toggle"
+import { usePathname } from "next/navigation"
+
 
 export interface NavbarProps {
   appTitle?: string
@@ -34,6 +36,9 @@ export function Navbar({
   rightContent,
   onSearch,
 }: NavbarProps) {
+  const pathname = usePathname()
+  const hideNotifications = pathname.startsWith("/qoc")
+
   return (
     <header className="flex h-14 items-center gap-4 border-b bg-background px-4 lg:h-[60px]">
       <SidebarTrigger className="lg:hidden" />
@@ -70,14 +75,14 @@ export function Navbar({
 
         {showThemeToggle && <ThemeToggle />}
 
-        {showNotifications && (
+        {showNotifications && !hideNotifications && (
           <Button variant="ghost" size="icon" className="rounded-full">
             <Bell className="h-5 w-5" />
             <span className="sr-only">Notifications</span>
           </Button>
         )}
 
-        {showHelp && (
+        {showHelp && !hideNotifications && (
           <Button variant="ghost" size="icon" className="rounded-full">
             <HelpCircle className="h-5 w-5" />
             <span className="sr-only">Help</span>

--- a/packages/db/generated/client/edge.js
+++ b/packages/db/generated/client/edge.js
@@ -185,7 +185,7 @@ const config = {
       "value": "prisma-client-js"
     },
     "output": {
-      "value": "/Users/vverma/Programming /ERP-SYS/packages/db/generated/client",
+      "value": "/Users/hiya_38/Desktop/ERP-SYS/packages/db/generated/client",
       "fromEnvVar": null
     },
     "config": {
@@ -194,17 +194,16 @@ const config = {
     "binaryTargets": [
       {
         "fromEnvVar": null,
-        "value": "darwin-arm64",
+        "value": "darwin",
         "native": true
       }
     ],
     "previewFeatures": [],
-    "sourceFilePath": "/Users/vverma/Programming /ERP-SYS/packages/db/prisma/schema.prisma",
+    "sourceFilePath": "/Users/hiya_38/Desktop/ERP-SYS/packages/db/prisma/schema.prisma",
     "isCustomOutput": true
   },
   "relativeEnvPaths": {
-    "rootEnvPath": null,
-    "schemaEnvPath": "../../.env"
+    "rootEnvPath": null
   },
   "relativePath": "../../prisma",
   "clientVersion": "6.5.0",

--- a/packages/db/generated/client/index.js
+++ b/packages/db/generated/client/index.js
@@ -186,7 +186,7 @@ const config = {
       "value": "prisma-client-js"
     },
     "output": {
-      "value": "/Users/vverma/Programming /ERP-SYS/packages/db/generated/client",
+      "value": "/Users/hiya_38/Desktop/ERP-SYS/packages/db/generated/client",
       "fromEnvVar": null
     },
     "config": {
@@ -195,17 +195,16 @@ const config = {
     "binaryTargets": [
       {
         "fromEnvVar": null,
-        "value": "darwin-arm64",
+        "value": "darwin",
         "native": true
       }
     ],
     "previewFeatures": [],
-    "sourceFilePath": "/Users/vverma/Programming /ERP-SYS/packages/db/prisma/schema.prisma",
+    "sourceFilePath": "/Users/hiya_38/Desktop/ERP-SYS/packages/db/prisma/schema.prisma",
     "isCustomOutput": true
   },
   "relativeEnvPaths": {
-    "rootEnvPath": null,
-    "schemaEnvPath": "../../.env"
+    "rootEnvPath": null
   },
   "relativePath": "../../prisma",
   "clientVersion": "6.5.0",
@@ -263,8 +262,8 @@ exports.PrismaClient = PrismaClient
 Object.assign(exports, Prisma)
 
 // file annotations for bundling tools to include these files
-path.join(__dirname, "libquery_engine-darwin-arm64.dylib.node");
-path.join(process.cwd(), "generated/client/libquery_engine-darwin-arm64.dylib.node")
+path.join(__dirname, "libquery_engine-darwin.dylib.node");
+path.join(process.cwd(), "generated/client/libquery_engine-darwin.dylib.node")
 // file annotations for bundling tools to include these files
 path.join(__dirname, "schema.prisma");
 path.join(process.cwd(), "generated/client/schema.prisma")


### PR DESCRIPTION
## Summary by Sourcery

Enhancements:
- Conditionally hide notification and help icons when on the QOC dashboard route